### PR TITLE
Støtte grad ikke er satt i søknaden

### DIFF
--- a/src/main/kotlin/no/nav/helse/prosessering/v1/ArbeidsgiverUtils.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/ArbeidsgiverUtils.kt
@@ -2,49 +2,8 @@ package no.nav.helse.prosessering.v1
 
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.time.Duration
 
-internal object ArbeidsgiverUtils {
-    private val ETT_MINUTT = Duration.ofMinutes(1)
-    private const val HUNDRE = 100.00
-
-    private fun kalkulerProsentAndelAvNormalArbeidsuke(
-        normalArbeidsuke: Duration,
-        redusertArbeidsuke: Duration) = BigDecimal(HUNDRE.div(normalArbeidsuke.seconds).times(redusertArbeidsuke.seconds)).setScale(2, RoundingMode.HALF_UP).toDouble()
-
-    private fun Duration.erSatt() = compareTo(ETT_MINUTT) >= 0
-
-    private fun Long.formaterMinutter() = "$this minutt${ if(this > 1) "er" else ""}"
-    private fun Long.formaterTimer() = "$this time${ if(this > 1) "r" else ""}"
-    private fun Duration.formaterTilTimerOgMinutter() : String {
-        val timer = seconds / 3600
-        val minutter = (seconds % 3600) / 60
-        return if (timer > 0 && minutter > 0) "${timer.formaterTimer()} og ${minutter.formaterMinutter()}"
-        else if (timer > 0) timer.formaterTimer()
-        else minutter.formaterMinutter()
-    }
-
-    internal fun prosentAvNormalArbeidsuke(
-        normalArbeidsuke: Duration?,
-        redusertArbeidsuke: Duration?
-    ) : Double? {
-        return if (normalArbeidsuke == null || redusertArbeidsuke == null) null
-        else if (redusertArbeidsuke.isZero) 0.0
-        else kalkulerProsentAndelAvNormalArbeidsuke(normalArbeidsuke, redusertArbeidsuke)
-    }
-
-    internal fun totalNormalArbeidsuke(arbeidsgivere: Arbeidsgivere) : String? {
-        var normalArbeidsuke = Duration.ZERO
-
-        arbeidsgivere.organisasjoner
-            .filter { it.normalArbeidsuke != null }
-            .forEach { normalArbeidsuke = normalArbeidsuke.plus(it.normalArbeidsuke) }
-
-        return when {
-            normalArbeidsuke.erSatt() -> "Jobber normalt ${normalArbeidsuke.formaterTilTimerOgMinutter()} per uke."
-            else -> null
-        }
-    }
-}
-internal fun Double.formatertMedToDesimaler() = String.format("%.2f", this)
+internal fun Double.avrundetMedEnDesimal() = BigDecimal(this).setScale(1, RoundingMode.HALF_UP).toDouble()
+internal fun Double.formatertMedEnDesimal() = String.format("%.1f", this)
 internal fun Organisasjon.formaterOrganisasjonsnummer() = if (organisasjonsnummer.length == 9) "${organisasjonsnummer.substring(0,3)} ${organisasjonsnummer.substring(3,6)} ${organisasjonsnummer.substring(6)}" else organisasjonsnummer
+internal fun Double.redusertArbeidsprosentTilInntektstap() = 100.0 - this

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/InntektstapUtils.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/InntektstapUtils.kt
@@ -1,7 +1,0 @@
-package no.nav.helse.prosessering.v1
-
-object InntektstapUtils {
-    private const val MAX_INNTEKTSTAP = 100.00
-
-    internal fun innktektstap(prosentAvNormalArbeidsUke: Double?) = if (prosentAvNormalArbeidsUke == null) null else MAX_INNTEKTSTAP - prosentAvNormalArbeidsUke
-}

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/MeldingV1.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/MeldingV1.kt
@@ -21,7 +21,8 @@ data class MeldingV1 (
     val grad : Int?,
     val harMedsoker : Boolean,
     val harForstattRettigheterOgPlikter : Boolean,
-    val harBekreftetOpplysninger : Boolean
+    val harBekreftetOpplysninger : Boolean,
+    val dagerPerUkeBorteFraJobb: Double? = null
 )
 
 data class Soker(
@@ -44,8 +45,7 @@ data class Arbeidsgivere(
 data class Organisasjon(
     val organisasjonsnummer: String,
     val navn: String?,
-    val normalArbeidsuke: Duration? = null,
-    val redusertArbeidsuke: Duration? = null
+    val redusertArbeidsprosent: Double? = null
 )
 
 data class Medlemskap(

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
@@ -65,6 +65,7 @@ internal class PdfV1Generator  {
                 "soknad_mottatt" to DATE_TIME_FORMATTER.format(melding.mottatt),
                 "har_medsoker" to melding.harMedsoker,
                 "grad" to melding.grad,
+                "dager_per_uke_borte_fra_jobb" to melding.dagerPerUkeBorteFraJobb?.avrundetMedEnDesimal()?.formatertMedEnDesimal(),
                 "soker" to mapOf(
                     "navn" to melding.soker.formatertNavn(),
                     "fodselsnummer" to melding.soker.formatertFodselsnummer(),
@@ -121,10 +122,15 @@ internal class PdfV1Generator  {
         .useFont({ ByteArrayInputStream(ITALIC_FONT) }, "Source Sans Pro", 400, BaseRendererBuilder.FontStyle.ITALIC, false)
 }
 
-private fun List<Organisasjon>.somMap() = map {mapOf<String,Any?>(
+private fun List<Organisasjon>.somMap() = map {
+    val redusertArbeidsprosent = it.redusertArbeidsprosent?.avrundetMedEnDesimal()
+    val inntektstap = redusertArbeidsprosent?.redusertArbeidsprosentTilInntektstap()
+
+    mapOf<String,Any?>(
         "navn" to it.navn,
         "organisasjonsnummer" to it.formaterOrganisasjonsnummer(),
-        "inntektstap" to InntektstapUtils.innktektstap(ArbeidsgiverUtils.prosentAvNormalArbeidsuke(it.normalArbeidsuke, it.redusertArbeidsuke))?.formatertMedToDesimaler()
+        "redusert_arbeidsprosent" to redusertArbeidsprosent?.formatertMedEnDesimal(),
+        "inntektstap" to inntektstap?.formatertMedEnDesimal()
     )
 }
 

--- a/src/main/resources/handlebars/soknad.hbs
+++ b/src/main/resources/handlebars/soknad.hbs
@@ -80,6 +80,9 @@
                     {{# if hjelp.sprak }}
                         <li>Det er valgt {{hjelp.sprak}} som språk i søknaden.</li>
                     {{/if}}
+                    {{# if dager_per_uke_borte_fra_jobb }}
+                        <li>Skal være {{dager_per_uke_borte_fra_jobb}} dager per uke borte fra jobb for å ta hånd om barnet.</li>
+                    {{/if}}
                 </ul>
             </div>
 
@@ -162,12 +165,9 @@
             {{/if}}
 
             <!-- ANNET -->
-            <h2><span>Annet</span></h2>
             {{# if grad }}
+                <h2><span>Annet</span></h2>
                 <p><span class="sporsmalstekst">Søker om grad: </span><span>{{ grad }}%</span></p>
-            {{/if}}
-            {{# if dager_per_uke_borte_fra_jobb }}
-                <p><span class="sporsmalstekst">Dager per uke borte fra jobb: </span><span>{{ dager_per_uke_borte_fra_jobb }}</span></p>
             {{/if}}
 
             <!-- SAMTYKKE -->

--- a/src/main/resources/handlebars/soknad.hbs
+++ b/src/main/resources/handlebars/soknad.hbs
@@ -80,20 +80,10 @@
                     {{# if hjelp.sprak }}
                         <li>Det er valgt {{hjelp.sprak}} som språk i søknaden.</li>
                     {{/if}}
-                    {{!--
-                    {{# if arbeidsgivere.har_arbeidsgivere }}
-                        {{# if hjelp.total_normal_arbeidsuke }}
-                            <li>{{hjelp.total_normal_arbeidsuke}}</li>
-                        {{/if}}
-                    {{else}}
-                        <li class="ikke_satt">Det er ikke valgt noen arbeidsgivere.</li>
-                    {{/if}}
-                    --}}
                 </ul>
             </div>
 
             <!-- ARBEIDSGIVERE -->
-
             {{# if arbeidsgivere.har_arbeidsgivere }}
             <h2><span>Arbeidsgivere</span></h2>
 
@@ -103,15 +93,11 @@
                 <ul>
 
                     <li>Organisasjonsnummer {{org.organisasjonsnummer}}</li>
-                    {{!--
                     <li>
-                        {{# if org.inntektstap }}
-                            Har et inntektstap på {{org.inntektstap}}%
-                        {{else}}
-                            <span class="ikke_satt">Ingen detaljer angitt for å utlede inntektstapet</span>
+                        {{# if org.redusert_arbeidsprosent }}
+                            Skal jobbe {{org.redusert_arbeidsprosent}}% av normal tid, har et inntektstap i denne stillingen på {{org.inntektstap}}%
                         {{/if}}
                     </li>
-                    --}}
                 </ul>
             {{/each}}
             </ul>
@@ -176,9 +162,12 @@
             {{/if}}
 
             <!-- ANNET -->
+            <h2><span>Annet</span></h2>
             {{# if grad }}
-                <h2><span>Annet</span></h2>
                 <p><span class="sporsmalstekst">Søker om grad: </span><span>{{ grad }}%</span></p>
+            {{/if}}
+            {{# if dager_per_uke_borte_fra_jobb }}
+                <p><span class="sporsmalstekst">Dager per uke borte fra jobb: </span><span>{{ dager_per_uke_borte_fra_jobb }}</span></p>
             {{/if}}
 
             <!-- SAMTYKKE -->

--- a/src/main/resources/handlebars/soknad.hbs
+++ b/src/main/resources/handlebars/soknad.hbs
@@ -81,7 +81,7 @@
                         <li>Det er valgt {{hjelp.sprak}} som språk i søknaden.</li>
                     {{/if}}
                     {{# if dager_per_uke_borte_fra_jobb }}
-                        <li>Skal være {{dager_per_uke_borte_fra_jobb}} dager per uke borte fra jobb for å ta hånd om barnet.</li>
+                        <li>Skal være borte fra jobb {{dager_per_uke_borte_fra_jobb}} dager per uke for å ta hånd om barnet.</li>
                     {{/if}}
                 </ul>
             </div>

--- a/src/test/kotlin/no/nav/helse/JournalforingsFormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/JournalforingsFormatTest.kt
@@ -1,8 +1,6 @@
 package no.nav.helse
 
 import no.nav.helse.dokument.JournalforingsFormat
-import no.nav.helse.dusseldorf.ktor.core.fromResources
-import no.nav.helse.prosessering.SoknadId
 import no.nav.helse.prosessering.v1.*
 import org.skyscreamer.jsonassert.JSONAssert
 import java.net.URI
@@ -42,8 +40,11 @@ class JournalforingsFormatTest {
                 "organisasjoner": [{
                     "organisasjonsnummer": "1212",
                     "navn": "Nei",
-                    "normal_arbeidsuke": null,
-                    "redusert_arbeidsuke": null
+                    "redusert_arbeidsprosent": null
+                },{
+                    "organisasjonsnummer": "54321",
+                    "navn": "Navn",
+                    "redusert_arbeidsprosent": 22.512
                 }]
             },
             "medlemskap": {
@@ -53,7 +54,8 @@ class JournalforingsFormatTest {
             "grad": 55,
             "har_medsoker": true,
             "har_bekreftet_opplysninger" : true,
-	        "har_forstatt_rettigheter_og_plikter": true
+	        "har_forstatt_rettigheter_og_plikter": true,
+            "dager_per_uke_borte_fra_jobb": 3.5
         }
         """.trimIndent(), String(json), true)
 
@@ -79,7 +81,8 @@ class JournalforingsFormatTest {
         relasjonTilBarnet = "Mor",
         arbeidsgivere = Arbeidsgivere(
             organisasjoner = listOf(
-                Organisasjon("1212", "Nei")
+                Organisasjon("1212", "Nei"),
+                Organisasjon("54321", "Navn", 22.512)
             )
         ),
         vedleggUrls = listOf(
@@ -93,6 +96,7 @@ class JournalforingsFormatTest {
         harMedsoker = true,
         grad = 55,
         harBekreftetOpplysninger = true,
-        harForstattRettigheterOgPlikter = true
+        harForstattRettigheterOgPlikter = true,
+        dagerPerUkeBorteFraJobb = 3.5
     )
 }

--- a/src/test/kotlin/no/nav/helse/PdfV1GeneratorTest.kt
+++ b/src/test/kotlin/no/nav/helse/PdfV1GeneratorTest.kt
@@ -2,7 +2,6 @@ package no.nav.helse
 
 import no.nav.helse.prosessering.v1.*
 import java.io.File
-import java.time.Duration
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import kotlin.test.Ignore
@@ -25,20 +24,16 @@ class PdfV1GeneratorTest {
             Organisasjon(
                 organisasjonsnummer = "975124568",
                 navn = "Kiwi",
-                normalArbeidsuke = Duration.ofHours(37).plusMinutes(1),
-                redusertArbeidsuke = Duration.ofHours(10).plusMinutes(45)
+                redusertArbeidsprosent = 22.00
             ),
             Organisasjon(
                 organisasjonsnummer = "952352687",
                 navn = "Bjerkheim gård",
-                normalArbeidsuke = Duration.ofHours(15).plusMinutes(50),
-                redusertArbeidsuke = Duration.ZERO
+                redusertArbeidsprosent = 50.665
             ),
             Organisasjon(
                 organisasjonsnummer = "952352655",
-                navn = "Hopp i havet",
-                normalArbeidsuke = Duration.ofHours(100),
-                redusertArbeidsuke = Duration.ofHours(81)
+                navn = "Hopp i havet"
             )
         ),
         barn: Barn = Barn(
@@ -47,7 +42,8 @@ class PdfV1GeneratorTest {
             alternativId = "29091884321"
         ),
         grad: Int? = 60,
-        harMedsoker: Boolean = true
+        harMedsoker: Boolean = true,
+        dagerPerUkeBorteFraJobb: Double? = 4.5
     ) = MeldingV1(
         sprak = sprak,
         soknadId = soknadId,
@@ -73,7 +69,8 @@ class PdfV1GeneratorTest {
         grad = grad,
         harMedsoker = harMedsoker,
         harForstattRettigheterOgPlikter = true,
-        harBekreftetOpplysninger = true
+        harBekreftetOpplysninger = true,
+        dagerPerUkeBorteFraJobb = dagerPerUkeBorteFraJobb
     )
 
     private fun genererOppsummeringsPdfer(writeBytes: Boolean) {
@@ -99,6 +96,10 @@ class PdfV1GeneratorTest {
 
         id = "6-utenGrad"
         pdf = generator.generateSoknadOppsummeringPdf(melding = gyldigMelding(soknadId = id, harMedsoker = false, organisasjoner = listOf(), barn = Barn(fodselsnummer = null, alternativId = null, navn = null), grad = null))
+        if (writeBytes) File(pdfPath(soknadId = id)).writeBytes(pdf)
+
+        id = "7-utenDagerBorteFraJobb"
+        pdf = generator.generateSoknadOppsummeringPdf(melding = gyldigMelding(soknadId = id, harMedsoker = false, organisasjoner = listOf(), barn = Barn(fodselsnummer = null, alternativId = null, navn = null), grad = null, dagerPerUkeBorteFraJobb = null))
         if (writeBytes) File(pdfPath(soknadId = id)).writeBytes(pdf)
     }
 

--- a/src/test/kotlin/no/nav/helse/PleiepengesoknadProsesseringTest.kt
+++ b/src/test/kotlin/no/nav/helse/PleiepengesoknadProsesseringTest.kt
@@ -133,21 +133,19 @@ class PleiepengesoknadProsesseringTest {
     }
 
     @Test
-    fun `Melding med språk og arbeidsuker satt blir prosessert`() {
+    fun `Melding med språk og redusert arbeidsprosent blir prosessert`() {
 
         val sprak = "nn"
-        val jobb1NormalArbeidsuke = Duration.ofHours(37).plusMinutes(30)
-        val jobb1RedusertArbeidsuke = Duration.ZERO
-        val jobb2NormalArbeidsuke = Duration.ofHours(25)
-        val jobb2RedusertArbeidsuke = Duration.ofHours(12).plusMinutes(30)
+        val jobb1RedusertArbeidsprosent = 50.422
+        val jobb2RedusertArbeidsprosent = 12.111
 
         val melding = gyldigMelding(
             fodselsnummerSoker = gyldigFodselsnummerA,
             fodselsnummerBarn = gyldigFodselsnummerB,
             sprak = sprak,
             organisasjoner = listOf(
-                Organisasjon("917755736", "Jobb1", normalArbeidsuke = jobb1NormalArbeidsuke, redusertArbeidsuke = jobb1RedusertArbeidsuke),
-                Organisasjon("917755737", "Jobb2", normalArbeidsuke = jobb2NormalArbeidsuke, redusertArbeidsuke = jobb2RedusertArbeidsuke)
+                Organisasjon("917755736", "Jobb1", jobb1RedusertArbeidsprosent),
+                Organisasjon("917755737", "Jobb2", jobb2RedusertArbeidsprosent)
             )
         )
 
@@ -159,10 +157,8 @@ class PleiepengesoknadProsesseringTest {
         val jobb2 = oppgaveOpprettet.melding.arbeidsgivere.organisasjoner.firstOrNull { it.navn == "Jobb2" }
         assertNotNull(jobb1)
         assertNotNull(jobb2)
-        assertEquals(jobb1NormalArbeidsuke, jobb1.normalArbeidsuke)
-        assertEquals(jobb1RedusertArbeidsuke, jobb1.redusertArbeidsuke)
-        assertEquals(jobb2NormalArbeidsuke, jobb2.normalArbeidsuke)
-        assertEquals(jobb2RedusertArbeidsuke, jobb2.redusertArbeidsuke)
+        assertEquals(jobb1RedusertArbeidsprosent, jobb1.redusertArbeidsprosent)
+        assertEquals(jobb2RedusertArbeidsprosent, jobb2.redusertArbeidsprosent)
     }
 
     @Test


### PR DESCRIPTION
Støtter fortsatt om grad er satt. Men også nye attributter (dagerPerUkeBorteFraJobb på søknaden, samt redusertArbeidsprosent per arbeidsgiver) som kan brukes til å avlede en mer korrekt grad