### PR TITLE
Arbeidsform fjernes fra dialogen

### DIFF
--- a/src/main/kotlin/no/nav/helse/felles/Arbeid.kt
+++ b/src/main/kotlin/no/nav/helse/felles/Arbeid.kt
@@ -1,7 +1,7 @@
 package no.nav.helse.felles
 
 data class Arbeidsforhold(
-    val arbeidsform: Arbeidsform,
+    val arbeidsform: Arbeidsform? = null, //Feltet skal fjernes, bruker optional for å støtte begge versjoner
     val jobberNormaltTimer: Double,
     val historiskArbeid: ArbeidIPeriode? = null,
     val planlagtArbeid: ArbeidIPeriode? = null

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
@@ -300,8 +300,8 @@ private fun Arbeidsforhold.somMap(
     skalViseHistoriskArbeid: Boolean = true,
     skalVisePlanlagtArbeid: Boolean = true
 ): Map<String, Any?> = mapOf(
-    "arbeidsform" to arbeidsform.utskriftsvennlig,
-    "jobberNormaltTimerTekst" to jobberNormaltTimer.somTekst(arbeidsform),
+    "arbeidsform" to arbeidsform?.utskriftsvennlig,
+    "jobberNormaltTimerTekst" to if(arbeidsform != null) jobberNormaltTimer.somTekst(arbeidsform) else null,
     "jobberNormaltTimer" to jobberNormaltTimer,
     "historiskArbeid" to historiskArbeid?.somMap(),
     "planlagtArbeid" to planlagtArbeid?.somMap(),

--- a/src/main/resources/handlebars/partial/arbeidsforholdPartial.hbs
+++ b/src/main/resources/handlebars/partial/arbeidsforholdPartial.hbs
@@ -1,6 +1,7 @@
 <li class="li-style-none">
     <ul>
         <li class="sporsmalstekst">{{arbeidsforhold.jobberNormaltTimerTekst}}</li>
+        <li class="sporsmalstekst">Jobber vanligvis {{arbeidsforhold.jobberNormaltTimer}} timer</li>
         {{#if arbeidsforhold.skalViseHistoriskArbeid}}
             {{#if arbeidsforhold.historiskArbeid}}
                 <li class="li-style-none">

--- a/src/test/kotlin/no/nav/helse/PdfV1GeneratorTest.kt
+++ b/src/test/kotlin/no/nav/helse/PdfV1GeneratorTest.kt
@@ -468,6 +468,46 @@ class PdfV1GeneratorTest {
             )
         )
         if (writeBytes) File(pdfPath(soknadId = id)).writeBytes(pdf)
+
+        id = "13-uten-arbeidsform-i-arbeidsforhold"
+        pdf = generator.generateSoknadOppsummeringPdf(
+            melding = fullGyldigMelding(id).copy(
+                frilans = Frilans(
+                    startdato = LocalDate.now().minusYears(3),
+                    sluttdato = LocalDate.now(),
+                    jobberFortsattSomFrilans = false,
+                    arbeidsforhold = Arbeidsforhold(
+                        jobberNormaltTimer = 23.0,
+                        historiskArbeid = ArbeidIPeriode(
+                            jobberIPerioden = JobberIPeriodeSvar.JA,
+                            jobberSomVanlig = true,
+                        ),
+                        planlagtArbeid = ArbeidIPeriode(
+                            jobberIPerioden = JobberIPeriodeSvar.JA,
+                            jobberSomVanlig = true
+                        )
+                    )
+                ),
+                arbeidsgivere = listOf(
+                    ArbeidsforholdAnsatt(
+                        navn = "Peppes",
+                        organisasjonsnummer = "917755736",
+                        erAnsatt = true,
+                        arbeidsforhold = Arbeidsforhold(
+                            jobberNormaltTimer = 27.0,
+                            historiskArbeid = ArbeidIPeriode(
+                                jobberIPerioden = JobberIPeriodeSvar.JA,
+                                jobberSomVanlig = true,
+                            ),
+                            planlagtArbeid = ArbeidIPeriode(
+                                jobberIPerioden = JobberIPeriodeSvar.NEI
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        if (writeBytes) File(pdfPath(soknadId = id)).writeBytes(pdf)
     }
 
     private fun pdfPath(soknadId: String) = "${System.getProperty("user.dir")}/generated-pdf-$soknadId.pdf"


### PR DESCRIPTION
Setter feltet som nullable for å støtte begge versjoner.

Legger til tekst som sier hvor mange timer man vanligvis jobber, som da vil erstatte jobberNormaltTimerTekst som inneholder arbeidsform og timer.