### PR TITLE
Filtrerer ut søknad som har kommet dobbelt.

### DIFF
--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/CleanupStream.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/CleanupStream.kt
@@ -3,12 +3,7 @@ package no.nav.helse.prosessering.v1.asynkron
 import no.nav.helse.CorrelationId
 import no.nav.helse.k9mellomlagring.DokumentEier
 import no.nav.helse.k9mellomlagring.K9MellomlagringService
-import no.nav.helse.kafka.KafkaConfig
-import no.nav.helse.kafka.ManagedKafkaStreams
-import no.nav.helse.kafka.ManagedStreamHealthy
-import no.nav.helse.kafka.ManagedStreamReady
-import no.nav.helse.kafka.TopicEntry
-import no.nav.helse.kafka.process
+import no.nav.helse.kafka.*
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
 import org.apache.kafka.streams.kstream.Consumed
@@ -41,6 +36,7 @@ internal class CleanupStream(
                     fraCleanup.name, Consumed.with(fraCleanup.keySerde, fraCleanup.valueSerde)
                 )
                 .filter {_, entry -> 1 == entry.metadata.version }
+                .filter { _, entry -> entry.metadata.correlationId != "generated-7a2a9f39-c333-49cb-b8ae-90f7f2b8bf1e" }
                 .mapValues { soknadId, entry ->
                     process(NAME, soknadId, entry) {
                         logger.info("Sletter dokumenter.")

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/JournalforingsStream.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/JournalforingsStream.kt
@@ -3,12 +3,7 @@ package no.nav.helse.prosessering.v1.asynkron
 import no.nav.helse.CorrelationId
 import no.nav.helse.felles.tilTpsNavn
 import no.nav.helse.joark.JoarkGateway
-import no.nav.helse.kafka.KafkaConfig
-import no.nav.helse.kafka.ManagedKafkaStreams
-import no.nav.helse.kafka.ManagedStreamHealthy
-import no.nav.helse.kafka.ManagedStreamReady
-import no.nav.helse.kafka.TopicEntry
-import no.nav.helse.kafka.process
+import no.nav.helse.kafka.*
 import no.nav.helse.prosessering.v1.PreprossesertMeldingV1
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
@@ -46,6 +41,7 @@ internal class JournalforingsStream(
                     Consumed.with(fraPreprossesert.keySerde, fraPreprossesert.valueSerde)
                 )
                 .filter { _, entry -> 1 == entry.metadata.version }
+                .filter { _, entry -> entry.metadata.correlationId != "generated-7a2a9f39-c333-49cb-b8ae-90f7f2b8bf1e" }
                 .mapValues { soknadId, entry ->
                     process(NAME, soknadId, entry) {
                         logger.info("Journalfører dokumenter.")


### PR DESCRIPTION
Sendt med noen millisekund forskjell og bruker samme vedlegg, som medfører at søknad nr 2 lager en propp fordi vedlegget er sletta. Søknad nr 1 er journalført. 